### PR TITLE
serializers for custom types

### DIFF
--- a/src/AggieEnterpriseApi/Generated/AggieEnterpriseClient.StrawberryShake.cs
+++ b/src/AggieEnterpriseApi/Generated/AggieEnterpriseClient.StrawberryShake.cs
@@ -3358,7 +3358,7 @@ namespace AggieEnterpriseApi
             }
         }
 
-        private global::System.Object? FormatDebitAmount(global::System.String? input)
+        private global::System.Object? FormatDebitAmount(global::System.Decimal? input)
         {
             if (input is null)
             {
@@ -3370,7 +3370,7 @@ namespace AggieEnterpriseApi
             }
         }
 
-        private global::System.Object? FormatCreditAmount(global::System.String? input)
+        private global::System.Object? FormatCreditAmount(global::System.Decimal? input)
         {
             if (input is null)
             {
@@ -3458,7 +3458,7 @@ namespace AggieEnterpriseApi
                 return false;
             }
 
-            return (((GlSegments is null && other.GlSegments is null) || GlSegments != null && GlSegments.Equals(other.GlSegments))) && ((GlSegmentString is null && other.GlSegmentString is null) || GlSegmentString != null && GlSegmentString.Equals(other.GlSegmentString)) && ((GlAliasCode is null && other.GlAliasCode is null) || GlAliasCode != null && GlAliasCode.Equals(other.GlAliasCode)) && ((PpmSegments is null && other.PpmSegments is null) || PpmSegments != null && PpmSegments.Equals(other.PpmSegments)) && ((PpmSegmentString is null && other.PpmSegmentString is null) || PpmSegmentString != null && PpmSegmentString.Equals(other.PpmSegmentString)) && ((DebitAmount is null && other.DebitAmount is null) || DebitAmount != null && DebitAmount.Equals(other.DebitAmount)) && ((CreditAmount is null && other.CreditAmount is null) || CreditAmount != null && CreditAmount.Equals(other.CreditAmount)) && ExternalSystemIdentifier.Equals(other.ExternalSystemIdentifier) && ((ExternalSystemReference is null && other.ExternalSystemReference is null) || ExternalSystemReference != null && ExternalSystemReference.Equals(other.ExternalSystemReference)) && ((PpmComment is null && other.PpmComment is null) || PpmComment != null && PpmComment.Equals(other.PpmComment));
+            return (((GlSegments is null && other.GlSegments is null) || GlSegments != null && GlSegments.Equals(other.GlSegments))) && ((GlSegmentString is null && other.GlSegmentString is null) || GlSegmentString != null && GlSegmentString.Equals(other.GlSegmentString)) && ((GlAliasCode is null && other.GlAliasCode is null) || GlAliasCode != null && GlAliasCode.Equals(other.GlAliasCode)) && ((PpmSegments is null && other.PpmSegments is null) || PpmSegments != null && PpmSegments.Equals(other.PpmSegments)) && ((PpmSegmentString is null && other.PpmSegmentString is null) || PpmSegmentString != null && PpmSegmentString.Equals(other.PpmSegmentString)) && DebitAmount == other.DebitAmount && CreditAmount == other.CreditAmount && ExternalSystemIdentifier.Equals(other.ExternalSystemIdentifier) && ((ExternalSystemReference is null && other.ExternalSystemReference is null) || ExternalSystemReference != null && ExternalSystemReference.Equals(other.ExternalSystemReference)) && ((PpmComment is null && other.PpmComment is null) || PpmComment != null && PpmComment.Equals(other.PpmComment));
         }
 
         public override global::System.Int32 GetHashCode()
@@ -3526,9 +3526,9 @@ namespace AggieEnterpriseApi
         private global::System.Boolean _set_ppmSegments;
         private global::System.String? _value_ppmSegmentString;
         private global::System.Boolean _set_ppmSegmentString;
-        private global::System.String? _value_debitAmount;
+        private global::System.Decimal? _value_debitAmount;
         private global::System.Boolean _set_debitAmount;
-        private global::System.String? _value_creditAmount;
+        private global::System.Decimal? _value_creditAmount;
         private global::System.Boolean _set_creditAmount;
         private global::System.String _value_externalSystemIdentifier = default !;
         private global::System.Boolean _set_externalSystemIdentifier;
@@ -3597,7 +3597,7 @@ namespace AggieEnterpriseApi
 
         global::System.Boolean global::AggieEnterpriseApi.State.IGlJournalLineInputInfo.IsPpmSegmentStringSet => _set_ppmSegmentString;
         ///<summary>Debit amount of the GL transaction or PPM Cost.  Only one of debitAmount and creditAmount may be specified on a line.</summary>
-        public global::System.String? DebitAmount
+        public global::System.Decimal? DebitAmount
         {
             get => _value_debitAmount;
             set
@@ -3609,7 +3609,7 @@ namespace AggieEnterpriseApi
 
         global::System.Boolean global::AggieEnterpriseApi.State.IGlJournalLineInputInfo.IsDebitAmountSet => _set_debitAmount;
         ///<summary>Credit amount of the GL transaction or PPM Cost.  Only one of debitAmount and creditAmount may be specified on a line.</summary>
-        public global::System.String? CreditAmount
+        public global::System.Decimal? CreditAmount
         {
             get => _value_creditAmount;
             set
@@ -5864,7 +5864,7 @@ namespace AggieEnterpriseApi.State
         private readonly global::StrawberryShake.Serialization.ILeafValueParser<global::System.String, global::System.String> _nonEmptyTrimmedString15Parser;
         private readonly global::StrawberryShake.Serialization.ILeafValueParser<global::System.String, global::System.String> _glSegmentStringParser;
         private readonly global::StrawberryShake.Serialization.ILeafValueParser<global::System.String, global::System.String> _ppmSegmentStringParser;
-        private readonly global::StrawberryShake.Serialization.ILeafValueParser<global::System.String, global::System.String> _nonNegativeFloatParser;
+        private readonly global::StrawberryShake.Serialization.ILeafValueParser<global::System.Decimal, global::System.Decimal> _nonNegativeFloatParser;
         private readonly global::StrawberryShake.Serialization.ILeafValueParser<global::System.String, global::System.String> _glReferenceField10Parser;
         private readonly global::StrawberryShake.Serialization.ILeafValueParser<global::System.String, global::System.String> _glDescriptionField40Parser;
         private readonly global::StrawberryShake.Serialization.ILeafValueParser<global::System.String, global::System.String> _erpEntityCodeParser;
@@ -5903,7 +5903,7 @@ namespace AggieEnterpriseApi.State
             _nonEmptyTrimmedString15Parser = serializerResolver.GetLeafValueParser<global::System.String, global::System.String>("NonEmptyTrimmedString15") ?? throw new global::System.ArgumentException("No serializer for type `NonEmptyTrimmedString15` found.");
             _glSegmentStringParser = serializerResolver.GetLeafValueParser<global::System.String, global::System.String>("GlSegmentString") ?? throw new global::System.ArgumentException("No serializer for type `GlSegmentString` found.");
             _ppmSegmentStringParser = serializerResolver.GetLeafValueParser<global::System.String, global::System.String>("PpmSegmentString") ?? throw new global::System.ArgumentException("No serializer for type `PpmSegmentString` found.");
-            _nonNegativeFloatParser = serializerResolver.GetLeafValueParser<global::System.String, global::System.String>("NonNegativeFloat") ?? throw new global::System.ArgumentException("No serializer for type `NonNegativeFloat` found.");
+            _nonNegativeFloatParser = serializerResolver.GetLeafValueParser<global::System.Decimal, global::System.Decimal>("NonNegativeFloat") ?? throw new global::System.ArgumentException("No serializer for type `NonNegativeFloat` found.");
             _glReferenceField10Parser = serializerResolver.GetLeafValueParser<global::System.String, global::System.String>("GlReferenceField10") ?? throw new global::System.ArgumentException("No serializer for type `GlReferenceField10` found.");
             _glDescriptionField40Parser = serializerResolver.GetLeafValueParser<global::System.String, global::System.String>("GlDescriptionField40") ?? throw new global::System.ArgumentException("No serializer for type `GlDescriptionField40` found.");
             _erpEntityCodeParser = serializerResolver.GetLeafValueParser<global::System.String, global::System.String>("ErpEntityCode") ?? throw new global::System.ArgumentException("No serializer for type `ErpEntityCode` found.");
@@ -7027,7 +7027,6 @@ namespace Microsoft.Extensions.DependencyInjection
             global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton<global::StrawberryShake.Serialization.ISerializer>(services, new global::StrawberryShake.Serialization.StringSerializer("NonEmptyTrimmedString15"));
             global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton<global::StrawberryShake.Serialization.ISerializer>(services, new global::StrawberryShake.Serialization.StringSerializer("GlSegmentString"));
             global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton<global::StrawberryShake.Serialization.ISerializer>(services, new global::StrawberryShake.Serialization.StringSerializer("PpmSegmentString"));
-            global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton<global::StrawberryShake.Serialization.ISerializer>(services, new global::StrawberryShake.Serialization.StringSerializer("NonNegativeFloat"));
             global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton<global::StrawberryShake.Serialization.ISerializer>(services, new global::StrawberryShake.Serialization.StringSerializer("GlReferenceField10"));
             global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton<global::StrawberryShake.Serialization.ISerializer>(services, new global::StrawberryShake.Serialization.StringSerializer("GlDescriptionField40"));
             global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton<global::StrawberryShake.Serialization.ISerializer>(services, new global::StrawberryShake.Serialization.StringSerializer("ErpEntityCode"));

--- a/src/AggieEnterpriseApi/GraphQlClient.cs
+++ b/src/AggieEnterpriseApi/GraphQlClient.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using AggieEnterpriseApi.Serializers;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace AggieEnterpriseApi;
 
@@ -10,7 +11,11 @@ public class GraphQlClient
 
         var serviceCollection = new ServiceCollection();
         
-        // TODO: likely need serializers for custom int/float types (ex: PositiveInt)
+        // add in serializers for custom int/float types (ex: PositiveInt)
+        serviceCollection.AddSerializer<PositiveIntSerializer>();
+        serviceCollection.AddSerializer<NonNegativeIntSerializer>();
+        serviceCollection.AddSerializer<NonPositiveIntSerializer>();
+        serviceCollection.AddSerializer<NonNegativeFloatSerializer>();
 
         serviceCollection
             .AddAggieEnterpriseClient()

--- a/src/AggieEnterpriseApi/Serializers/Scalars.cs
+++ b/src/AggieEnterpriseApi/Serializers/Scalars.cs
@@ -1,0 +1,43 @@
+using StrawberryShake.Serialization;
+
+namespace AggieEnterpriseApi.Serializers;
+
+public class PositiveIntSerializer : ScalarSerializer<int>
+{
+    public PositiveIntSerializer()
+        : base(
+            // the name of the scalar
+            "PositiveInt")
+    {
+    }
+}
+
+public class NonNegativeIntSerializer : ScalarSerializer<int>
+{
+    public NonNegativeIntSerializer()
+        : base(
+            // the name of the scalar
+            "NonNegativeInt")
+    {
+    }
+}
+
+public class NonPositiveIntSerializer : ScalarSerializer<int>
+{
+    public NonPositiveIntSerializer()
+        : base(
+            // the name of the scalar
+            "NonPositiveInt")
+    {
+    }
+}
+
+public class NonNegativeFloatSerializer : ScalarSerializer<decimal>
+{
+    public NonNegativeFloatSerializer()
+        : base(
+            // the name of the scalar
+            "NonNegativeFloat")
+    {
+    }
+}

--- a/src/AggieEnterpriseApi/schema.extensions.graphql
+++ b/src/AggieEnterpriseApi/schema.extensions.graphql
@@ -11,3 +11,19 @@ directive @enumValue(value: String!) on ENUM_VALUE
 directive @rename(name: String!) on INPUT_FIELD_DEFINITION | INPUT_OBJECT | ENUM | ENUM_VALUE
 
 extend schema @key(fields: "id")
+
+extend scalar PositiveInt
+    @serializationType(name: "global::System.Int32")
+    @runtimeType(name: "global::System.Int32")
+
+extend scalar NonNegativeInt
+    @serializationType(name: "global::System.Int32")
+    @runtimeType(name: "global::System.Int32")
+
+extend scalar NonPositiveInt
+    @serializationType(name: "global::System.Int32")
+    @runtimeType(name: "global::System.Int32")
+    
+extend scalar NonNegativeFloat
+    @serializationType(name: "global::System.Decimal")
+    @runtimeType(name: "global::System.Decimal")

--- a/test/ApiTests/GlJournalTests.cs
+++ b/test/ApiTests/GlJournalTests.cs
@@ -51,14 +51,14 @@ public class GlJournalTests : TestBase
                     new GlJournalLineInput
                     {
                         GlSegmentString = "3110-12100-0100322-410030-00-000-0000000000-000000-0000-000000-000000",
-                        DebitAmount = "100.00", // TODO: why not decimal?
+                        DebitAmount = 100.00m,
                         ExternalSystemIdentifier = "ITEMX",
                         ExternalSystemReference = "CYBERSOURCE-Deposit",
                     },
                     new GlJournalLineInput
                     {
                         GlSegmentString = "3110-U1310-0100333-410058-00-000-0000000000-000000-0000-000000-000000",
-                        CreditAmount = "100.00", // TODO: why not decimal?
+                        CreditAmount = 100.00m,
                         ExternalSystemIdentifier = "ITEMX",
                         ExternalSystemReference = "CYBERSOURCE-Deposit",
                     }

--- a/test/ApiTests/GlJournalTests.cs
+++ b/test/ApiTests/GlJournalTests.cs
@@ -72,4 +72,58 @@ public class GlJournalTests : TestBase
         data.GlJournalRequest.RequestStatus.RequestStatus.ShouldBe(RequestStatus.Pending);
         data.GlJournalRequest.ValidationResults.ShouldBeNull(); // shouldn't be any errors
     }
+
+    [Fact]
+    public async Task CreateInValidJournal()
+    {
+        var client = AggieEnterpriseApi.GraphQlClient.Get(GraphQlUrl, Token);
+
+        var newJournalEntry = await client.GlJournalRequest.ExecuteAsync(new GlJournalRequestInput
+        {
+            Header = new ActionRequestHeaderInput
+            {
+                ConsumerTrackingId = Guid.NewGuid().ToString(),
+                ConsumerReferenceId = "ORDER_12345",
+                ConsumerNotes = "Invoices for CAES Payments",
+                BoundaryApplicationName = "CAES Payments"
+            },
+            Payload = new GlJournalInput
+            {
+                JournalSourceName = "BOUNDARY_APP_1",
+                JournalCategoryName = "INTERCOMPANY_REVENUE",
+                JournalName = "Recharges July 2023",
+                JournalReference = "ORDER_12345",
+                JournalLines = new[]
+                {
+                    new GlJournalLineInput
+                    {
+                        GlSegmentString = "3110-12100-0100322-410030-00-000-0000000000-000000-0000-000000-000000",
+                        DebitAmount = 100.01m,
+                        ExternalSystemIdentifier = "ITEMX",
+                        ExternalSystemReference = "CYBERSOURCE-Deposit",
+                    },
+                    new GlJournalLineInput
+                    {
+                        GlSegmentString = "3110-U1310-0100333-410058-00-000-0000000000-000000-0000-000000-000000",
+                        CreditAmount = 100.00m,
+                        ExternalSystemIdentifier = "ITEMX",
+                        ExternalSystemReference = "CYBERSOURCE-Deposit",
+                    }
+                }
+            }
+        });
+
+        var data = newJournalEntry.ReadData();
+
+        
+        data.GlJournalRequest.ShouldNotBeNull();
+        data.GlJournalRequest.RequestStatus.RequestStatus.ShouldBe(RequestStatus.Rejected);
+        data.GlJournalRequest.ValidationResults.ShouldNotBeNull();
+        data.GlJournalRequest.ValidationResults.ErrorMessages.Count.ShouldBe(1);
+        data.GlJournalRequest.ValidationResults.ErrorMessages[0].ShouldBe("Credits and debits of journal lines must balance to zero.");
+        data.GlJournalRequest.ValidationResults.MessageProperties.ShouldNotBeNull();
+        data.GlJournalRequest.ValidationResults.MessageProperties.Count.ShouldBe(1);
+        data.GlJournalRequest.ValidationResults.MessageProperties[0].ShouldBe("journalLines.[creditAmount | debitAmount]");
+        // data.GlJournalRequest.ValidationResults
+    }
 }


### PR DESCRIPTION
any of the custom scalar types we want to use, ex: `NonNegativeFloat` will default to `string` unless we create a custom extension and serializer for them.  I've created 4 for the common int and decimal types.  Note I used a `decimal` type for `NonNegativeFloat` even though a `double` might be better, but since this is a financial system I want to start with decimal and go from there.