### PR TITLE
Ability to grab query client using auto-refreshing oauth access JWTs

### DIFF
--- a/src/AggieEnterpriseApi/AggieEnterpriseApi.csproj
+++ b/src/AggieEnterpriseApi/AggieEnterpriseApi.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageId>AggieEnterpriseApi</PackageId>
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="StrawberryShake.CodeGeneration.CSharp.Analyzers" Version="12.16.0" />

--- a/src/AggieEnterpriseApi/Authentication/TokenService.cs
+++ b/src/AggieEnterpriseApi/Authentication/TokenService.cs
@@ -1,0 +1,59 @@
+using System.Net.Http.Json;
+using System.Text;
+
+namespace AggieEnterpriseApi.Authentication;
+
+public class TokenService
+{
+    private readonly IHttpClientFactory _clientFactory;
+
+    public TokenService(IHttpClientFactory clientFactory)
+    {
+        _clientFactory = clientFactory;
+    }
+
+    public async Task<string> GetValidToken(string url, string key, string secret, string scope)
+    {
+        var httpClient = _clientFactory.CreateClient();
+
+        // baseUrl is just host + port
+        var baseUrl = new Uri(url).GetLeftPart(UriPartial.Authority);
+
+        // set auth with our consumer key and secret
+        httpClient.DefaultRequestHeaders.Add("Authorization",
+            "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{key}:{secret}")));
+
+        // set the content type
+        httpClient.DefaultRequestHeaders.Add("Content-Type", "application/x-www-form-urlencoded");
+
+        // set the scope
+        var tokenUrl = $"{baseUrl}/oauth2/token";
+
+        // setup the request content
+        var content = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("grant_type", "client_credentials"),
+            new KeyValuePair<string, string>("scope", scope)
+        });
+
+        // make the request
+        var request = await httpClient.PostAsync(tokenUrl, content);
+
+        // error if we didn't get a 200
+        request.EnsureSuccessStatusCode();
+
+        // get back json with our JWT in access_token
+        var response = await request.Content.ReadFromJsonAsync<TokenResponse>();
+
+        // return the token
+        return response.access_token;
+    }
+
+    private class TokenResponse
+    {
+        public string access_token { get; set; }
+        public string token_type { get; set; }
+        public int expires_in { get; set; }
+        public string scope { get; set; }
+    }
+}

--- a/src/AggieEnterpriseApi/GraphQlClient.cs
+++ b/src/AggieEnterpriseApi/GraphQlClient.cs
@@ -5,6 +5,40 @@ namespace AggieEnterpriseApi;
 
 public class GraphQlClient
 {
+    /// <summary>
+    /// Returns an IAggieEnterpriseClient that uses consumer key and secret to generate new access tokens as needed
+    /// </summary>
+    /// <param name="url">URL for AE API</param>
+    /// <param name="key">Consumer Key</param>
+    /// <param name="secret">Consumer Secret</param>
+    /// <param name="scope">Optional scope to avoid collisions. Each app should provide their own scope</param>
+    /// <returns></returns>
+    public static IAggieEnterpriseClient Get(string url, string key, string secret, string scope = "default")
+    {
+        var graphQlUri = new Uri(url);
+
+        var serviceCollection = new ServiceCollection();
+        
+        // add in serializers for custom int/float types (ex: PositiveInt)
+        serviceCollection.AddSerializer<PositiveIntSerializer>();
+        serviceCollection.AddSerializer<NonNegativeIntSerializer>();
+        serviceCollection.AddSerializer<NonPositiveIntSerializer>();
+        serviceCollection.AddSerializer<NonNegativeFloatSerializer>();
+
+        serviceCollection
+            .AddAggieEnterpriseClient()
+            .ConfigureHttpClient((serviceProvider, client) =>
+            {
+                client.BaseAddress = graphQlUri;
+                var token = serviceProvider.GetRequiredService<TODO>();
+                client.DefaultRequestHeaders.Add("Authorization", "Bearer " + token);
+            });
+
+        IServiceProvider services = serviceCollection.BuildServiceProvider();
+
+        return services.GetRequiredService<IAggieEnterpriseClient>();
+    }
+    
     public static IAggieEnterpriseClient Get(string url, string token)
     {
         var graphQlUri = new Uri(url);

--- a/test/ApiTests/Authentication/AuthTests.cs
+++ b/test/ApiTests/Authentication/AuthTests.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using AggieEnterpriseApi.Extensions;
+using Shouldly;
+using Xunit;
+
+namespace ApiTests.Authentication;
+
+public class AuthTests
+{
+    [Fact]
+    public async Task CanGetClient()
+    {
+        var client = AggieEnterpriseApi.GraphQlClient.Get("", "",  "", "", "apitests");
+        
+        client.ShouldNotBeNull();
+        
+        var result = await client.DeptParents.ExecuteAsync("ACBS001");
+        
+        var data = result.ReadData();
+        
+        data.ShouldNotBeNull();
+    }
+}


### PR DESCRIPTION
When grabbing a `GraphQLClient` there is now an overload for grabbing one that'll pull tokens as-needed using the oauth2/token endpoint.  Basically it uses the key/secret to request a new token, and then stores that token until a minute before it's going to expire.  When you go to grab a new client, it'll look in the cache and either pull the still-active auth key or generate a new one.

Added in "scope" param -- it's optional but as things stand now, generating new tokens will invalidate the old ones (dumb).  So each app should provide one.