### PR TITLE
move auth into httpClient message handler

### DIFF
--- a/src/AggieEnterpriseApi/Authentication/AuthenticationDelegatingHandler.cs
+++ b/src/AggieEnterpriseApi/Authentication/AuthenticationDelegatingHandler.cs
@@ -1,0 +1,41 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace AggieEnterpriseApi.Authentication;
+
+/// <summary>
+/// On any http call, get the bearer token from the token service and add it to the request.
+/// If unauthorized, get a new token and try again once.
+/// </summary>
+public class AuthenticationDelegatingHandler : DelegatingHandler
+{
+    private const string BearerScheme = "Bearer";
+    
+    private readonly ITokenService _tokenService;
+    private readonly GraphQlClientOptions _options;
+
+    public AuthenticationDelegatingHandler(ITokenService tokenService, GraphQlClientOptions options)
+    {
+        _tokenService = tokenService;
+        _options = options;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var token = await _tokenService.GetValidToken(_options);
+
+        request.Headers.Authorization = new AuthenticationHeaderValue(BearerScheme, token);
+
+        var response = await base.SendAsync(request, cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
+        {
+            token = await _tokenService.GetValidToken(_options);
+            request.Headers.Authorization = new AuthenticationHeaderValue(BearerScheme, token);
+            response = await base.SendAsync(request, cancellationToken);
+        }
+
+        return response;
+    }
+}

--- a/src/AggieEnterpriseApi/Authentication/TokenService.cs
+++ b/src/AggieEnterpriseApi/Authentication/TokenService.cs
@@ -7,6 +7,7 @@ namespace AggieEnterpriseApi.Authentication;
 
 public interface ITokenService
 {
+    Task<string> GetValidToken(GraphQlClientOptions options);
     Task<string> GetValidToken(string url, string key, string secret, string scope);
 }
 
@@ -21,6 +22,11 @@ public class TokenService : ITokenService
     {
         _clientFactory = clientFactory;
         _memoryCache = memoryCache;
+    }
+    
+    public async Task<string> GetValidToken(GraphQlClientOptions options)
+    {
+        return await GetValidToken(options.TokenEndpoint, options.Key, options.Secret, options.Scope);
     }
 
     public async Task<string> GetValidToken(string tokenUrl, string key, string secret, string scope)

--- a/src/AggieEnterpriseApi/GraphQlClientOptions.cs
+++ b/src/AggieEnterpriseApi/GraphQlClientOptions.cs
@@ -1,0 +1,20 @@
+namespace AggieEnterpriseApi;
+
+public class GraphQlClientOptions
+{
+    public GraphQlClientOptions(string queryEndpoint, string tokenEndpoint, string key, string secret,
+        string scope = "default")
+    {
+        QueryEndpoint = queryEndpoint;
+        TokenEndpoint = tokenEndpoint;
+        Key = key;
+        Secret = secret;
+        Scope = scope;
+    }
+
+    public string QueryEndpoint { get; set; }
+    public string TokenEndpoint { get; set; }
+    public string Key { get; set; }
+    public string Secret { get; set; }
+    public string Scope { get; set; }
+}


### PR DESCRIPTION
Still uses the same token service in the background, but also will retry on 401/403 in case we get an edge case where the token expires