### PR TITLE
Slightly safer token generation logic

### DIFF
--- a/src/AggieEnterpriseApi/Authentication/AuthenticationDelegatingHandler.cs
+++ b/src/AggieEnterpriseApi/Authentication/AuthenticationDelegatingHandler.cs
@@ -10,7 +10,7 @@ namespace AggieEnterpriseApi.Authentication;
 public class AuthenticationDelegatingHandler : DelegatingHandler
 {
     private const string BearerScheme = "Bearer";
-    
+
     private readonly ITokenService _tokenService;
     private readonly GraphQlClientOptions _options;
 
@@ -31,8 +31,13 @@ public class AuthenticationDelegatingHandler : DelegatingHandler
 
         if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
         {
+            // if we get unauthorized, clear the token cache and try again
+            _tokenService.ClearTokenCache();
+
             token = await _tokenService.GetValidToken(_options);
+
             request.Headers.Authorization = new AuthenticationHeaderValue(BearerScheme, token);
+
             response = await base.SendAsync(request, cancellationToken);
         }
 

--- a/src/AggieEnterpriseApi/Authentication/AuthenticationDelegatingHandler.cs
+++ b/src/AggieEnterpriseApi/Authentication/AuthenticationDelegatingHandler.cs
@@ -32,7 +32,7 @@ public class AuthenticationDelegatingHandler : DelegatingHandler
         if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
         {
             // if we get unauthorized, clear the token cache and try again
-            _tokenService.ClearTokenCache();
+            _tokenService.ClearTokenCache(_options);
 
             token = await _tokenService.GetValidToken(_options);
 

--- a/src/AggieEnterpriseApi/Authentication/TokenService.cs
+++ b/src/AggieEnterpriseApi/Authentication/TokenService.cs
@@ -13,6 +13,9 @@ public interface ITokenService
 
 public class TokenService : ITokenService
 {
+    // set buffer time in seconds
+    private const int BufferTime = 300;
+    
     //Instantiate a Singleton of the Semaphore with a value of 1. This means that only 1 thread can be granted access at a time.
     private static readonly SemaphoreSlim SemaphoreSlim = new SemaphoreSlim(1, 1);
 
@@ -86,11 +89,9 @@ public class TokenService : ITokenService
             {
                 throw new Exception("Invalid response from Aggie Enterprise API. Access token was not returned.");
             }
-            
-            // TODO: read the JWT to get expiration date and use that instead of expires_in
 
-            // cache the token for expired_in seconds (minus 60 seconds for safety)
-            _memoryCache.Set(TokenCacheKey, response.access_token, TimeSpan.FromSeconds(response.expires_in - 60));
+            // cache the token for expired_in seconds (minus a little for safety)
+            _memoryCache.Set(TokenCacheKey, response.access_token, TimeSpan.FromSeconds(response.expires_in - BufferTime));
 
             // return the token
             return response.access_token;


### PR DESCRIPTION
Two main changes to make token generation safer:
1. Use a semaphore locked to a single thread to prevent multiple callers from generating a new token, since only one token can be live at a time.  If two callers enter at the same time, the second should be locked out until a token is acquired by the first thread.  The second thread is then allowed to enter and checks the cache a second time, which should now be populated.
2. If we get unauthorized back from the GraphQL API, explicitly clear the cache and grab a new token before retrying