### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in the repo.
+*   @jsylvestre
+*   @srkirkland
+*   @sprucely


### PR DESCRIPTION
CODEOWNERS is needed so that branch protection rules can be setup to prevent random merges.