### PR TITLE
Adds ping API endpoint

### DIFF
--- a/src/AggieEnterpriseApi/Queries/PingApi.graphql
+++ b/src/AggieEnterpriseApi/Queries/PingApi.graphql
@@ -1,0 +1,5 @@
+query PingApi {
+    erpEntity(code: "3110") {
+        code
+    }
+}

--- a/test/ApiTests/ChartValidationTests.cs
+++ b/test/ApiTests/ChartValidationTests.cs
@@ -10,6 +10,20 @@ using Microsoft.Extensions.Configuration;
 namespace ApiTests;
 public class ChartValidationTests : TestBase
 {
+    [Fact] 
+    async Task PingApiReturnsValue()
+    {
+        var client = GraphQlClient.Get(GraphQlUrl, TokenEndpoint, ConsumerKey, ConsumerSecret, $"{ScopeApp}-{ScopeEnv}");
+
+        var result = await client.PingApi.ExecuteAsync();
+        var data = result.ReadData();
+        data.ErpEntity.ShouldNotBeNull("ErpEntity should not be null");
+        data.ErpEntity.Code.ShouldBe("3110", "Entity code should be 3110");
+
+
+    }
+
+
     [Fact]
     public async Task ValidChartString()
     {


### PR DESCRIPTION
Adds a simple ping API endpoint and a test to verify that the API returns a value. This allows for a quick and easy way to check if the API is up and running.