### PR TITLE
Add dedicated FundDetails query and enrich fund attributes

### DIFF
--- a/src/AggieEnterpriseApi/Queries/DisplayDetailsGl.graphql
+++ b/src/AggieEnterpriseApi/Queries/DisplayDetailsGl.graphql
@@ -51,6 +51,9 @@ query DisplayDetailsGl(
     code
     name
     fundPurpose
+	giftFund
+    endowmentGiftFund
+	eligibleForUse
   }
   erpFinancialDepartment(code: $dept) {
     code

--- a/src/AggieEnterpriseApi/Queries/FundDetails.graphql
+++ b/src/AggieEnterpriseApi/Queries/FundDetails.graphql
@@ -1,0 +1,13 @@
+query FundDetails($code: String!) {
+      # pull single project back by number
+      erpFund(code: $code) {
+          id
+          code
+          name
+		  parentCode
+          fundPurpose
+          giftFund
+          endowmentGiftFund
+		  eligibleForUse
+      }
+    }

--- a/src/AggieEnterpriseApi/Queries/Segment/Erp/ErpFundSearch.graphql
+++ b/src/AggieEnterpriseApi/Queries/Segment/Erp/ErpFundSearch.graphql
@@ -4,7 +4,6 @@ query ErpFundSearch($filter: ErpFundFilterInput!, $code: String!) {
     id
     code
     name
-    fundPurpose
     eligibleForUse
     parentCode
   }
@@ -14,7 +13,6 @@ query ErpFundSearch($filter: ErpFundFilterInput!, $code: String!) {
       id
       code
       name
-      fundPurpose
       eligibleForUse
       parentCode
     }

--- a/test/ApiTests/FundTests.cs
+++ b/test/ApiTests/FundTests.cs
@@ -33,15 +33,14 @@ public class FundTests : TestBase
     }
 
     [Fact]
-    public async Task GetFundIncludesFundPurpose()
+    public async Task GetFundDetails()
     {
         const string fundCode = "36327";
         const string expectedFundPurpose = "Scholarships for such worthy students at the College of Agriculture located at Davis California";
 
         var client = AggieEnterpriseApi.GraphQlClient.Get(GraphQlUrl, TokenEndpoint, ConsumerKey, ConsumerSecret, $"{ScopeApp}-{ScopeEnv}");
 
-        var filter = new ErpFundFilterInput { Code = new StringFilterInput { Eq = fundCode } };
-        var result = await client.ErpFundSearch.ExecuteAsync(filter, fundCode);
+        var result = await client.FundDetails.ExecuteAsync(fundCode);
 
         var data = result.ReadData();
 
@@ -50,5 +49,7 @@ public class FundTests : TestBase
         data.ErpFund.ShouldNotBeNull();
         data.ErpFund.Code.ShouldBe(fundCode);
         data.ErpFund.FundPurpose.ShouldBe(expectedFundPurpose);
+        data.ErpFund.GiftFund.ShouldBeFalse();
+        data.ErpFund.EndowmentGiftFund.ShouldBeTrue();
     }
 }


### PR DESCRIPTION
Introduce a dedicated `FundDetails` GraphQL query to provide comprehensive information for a single fund, including `giftFund`, `endowmentGiftFund`, and `eligibleForUse`.

Refactor `ErpFundSearch` to exclusively handle fund search operations, separating single-fund lookups into the new `FundDetails` query. Update `DisplayDetailsGl` to also fetch these new fund attributes and remove `fundPurpose` from relevant fund queries.