### PR TITLE
Add dedicated query for employee's PPM projects and awards

### DIFF
--- a/src/AggieEnterpriseApi/Queries/PpmProjectAndAwardTeamByEmpId.graphql
+++ b/src/AggieEnterpriseApi/Queries/PpmProjectAndAwardTeamByEmpId.graphql
@@ -1,0 +1,23 @@
+query PpmProjectAndAwardTeamByEmpId(
+  $employeeId: UcEmployeeId!,
+  $roleName: NonEmptyTrimmedString60
+) {
+  ppmProjectByProjectTeamMemberEmployeeId(employeeId: $employeeId, roleName: $roleName) {
+    projectNumber
+    projectStatus
+    teamMembers {
+      employeeId
+      name
+      roleName
+    }
+	awards{
+		ppmAwardNumber
+		awardStatus 
+		personnel {
+			roleName
+			name
+			employeeId
+		}
+	}
+  }
+}

--- a/test/ApiTests/PpmTeamTests.cs
+++ b/test/ApiTests/PpmTeamTests.cs
@@ -20,4 +20,17 @@ public class PpmTeamTests : TestBase
         data.PpmProjectByProjectTeamMemberEmployeeId.ShouldNotBeEmpty();
 
     }
+
+    [Fact]
+    public async Task? GetProjectsForPerson2()
+    {
+        var client = AggieEnterpriseApi.GraphQlClient.Get(GraphQlUrl, TokenEndpoint, ConsumerKey, ConsumerSecret, $"{ScopeApp}-{ScopeEnv}");
+
+        var result = await client.PpmProjectAndAwardTeamByEmpId.ExecuteAsync("10727488", null);
+
+        var data = result.ReadData();
+
+        data.PpmProjectByProjectTeamMemberEmployeeId.ShouldNotBeEmpty();
+
+    }
 }


### PR DESCRIPTION
This query retrieves all PPM projects and awards where a specified employee is listed as a team member or personnel, providing a consolidated view of their involvement.